### PR TITLE
Fix for Fprintf address in print out

### DIFF
--- a/call_fprintf.c
+++ b/call_fprintf.c
@@ -250,7 +250,7 @@ int fprintf_process(pid_t pid) {
   void *their_fprintf = their_libc + ((void *)fprintf - our_libc);
   FILE *their_stderr = their_libc + ((void *)stderr - our_libc);
   printf("their libc           %p\n", their_libc);
-  printf("their fprintf        %p\n", their_libc);
+  printf("their fprintf        %p\n", their_fprintf);
   printf("their stderr         %p\n", their_stderr);
 
   // We want to make a call like:


### PR DESCRIPTION
This is great, I was trying to figure this out myself and came upon your example.  Currently trying to modify this code to run system in another process.  When I was going over the code I saw the wrong fprintf memory address was being printed out.     